### PR TITLE
Persist theme preference and clean up text

### DIFF
--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -4,7 +4,11 @@ import { SunIcon, MoonIcon } from '@heroicons/react/24/outline'
 export default function ThemeToggle() {
   const [isDark, setIsDark] = useState(() => {
     if (typeof window !== 'undefined') {
-      return document.documentElement.classList.contains('dark')
+      const savedTheme = localStorage.getItem('theme')
+      if (savedTheme) {
+        return savedTheme === 'dark'
+      }
+      return window.matchMedia('(prefers-color-scheme: dark)').matches
     }
     return false
   })

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -3,16 +3,18 @@ import { Link } from 'react-router-dom'
 export default function NotFound() {
   return (
     <div className="grid min-h-full place-items-center px-6 py-24 sm:py-32 lg:px-8">
-      <div className="text-center">
-        <p className="text-base font-semibold text-primary-600">404</p>
-        <h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">Page not found</h1>
-        <p className="mt-6 text-base leading-7 text-gray-600">Sorry, we couldn't find the page you're looking for.</p>
-        <div className="mt-10">
-          <Link to="/" className="btn btn-primary">
-            Go back home
-          </Link>
+        <div className="text-center">
+          <p className="text-base font-semibold text-primary-600">404</p>
+          <h1 className="mt-4 text-3xl font-bold tracking-tight text-gray-900 sm:text-5xl">Page not found</h1>
+          <p className="mt-6 text-base leading-7 text-gray-600">
+            Sorry, we couldn&apos;t find the page you&apos;re looking for.
+          </p>
+          <div className="mt-10">
+            <Link to="/" className="btn btn-primary">
+              Go back home
+            </Link>
+          </div>
         </div>
       </div>
-    </div>
-  )
-} 
+    )
+  }

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -53,7 +53,7 @@ export default function Profile() {
           </div>
         ) : (
           <div className="text-center py-12">
-            <p className="text-gray-500">You haven't listed any books yet.</p>
+            <p className="text-gray-500">You haven&apos;t listed any books yet.</p>
             <p className="text-sm text-gray-400 mt-2">
               Add your first book to start swapping!
             </p>


### PR DESCRIPTION
## Summary
- persist user's theme choice by reading saved preference or system setting
- fix unescaped apostrophes in NotFound and Profile pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899da50f7488332a1bb501e6d00fea8